### PR TITLE
Update code to support the rename of 'atom-shell' to 'Electron'. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # grunt-download-atom-shell
 
-Grunt tasks for downloading atom-shell, and the compatible version of `chromedriver`.
+Grunt tasks for downloading Electron, and the compatible version of `chromedriver`.
+Note: older versions of Electron will download with the old name of 'atom-shell'
 
 ## Installation
 
@@ -33,8 +34,8 @@ Add the necessary configuration to your `Gruntfile.js`:
 ```js
 module.exports = function(grunt) {
   grunt.initConfig({
-    'download-atom-shell': {
-      version: '0.20.3',
+    'download-electron-shell': {
+      version: '0.24.0',
       outputDir: 'my-dependencies'
     }
   });
@@ -46,9 +47,22 @@ or your `Gruntfile.coffee`:
 ```coffee
 module.exports = (grunt) ->
   grunt.initConfig
-    'download-atom-shell':
-      version: '0.20.3'
+    'download-electron-shell':
+      version: '0.24.0'
       outputDir: 'my-dependencies'
+```
+
+**Note!**  Older versions of Electron were named 'atom-shell'.  Due to some breaking changes introduced during the rename, if you want to use a version of Electron older than ```0.24.0``` then you should use the ```download-atom-shell``` task definition instead of ```download-electron-shell```
+
+```js
+module.exports = function(grunt) {
+  grunt.initConfig({
+    'download-atom-shell': {
+      version: '0.23.0',
+      outputDir: 'my-dependencies'
+    }
+  });
+};
 ```
 
 Then you can download atom-shell to the path you specified:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-download-atom-shell",
-  "description": "Grunt task to download atom-shell",
+  "description": "Grunt task to download Electron",
   "version": "0.12.0",
   "main": "grunt.js",
   "dependencies": {

--- a/tasks/download-electron-shell-task.coffee
+++ b/tasks/download-electron-shell-task.coffee
@@ -5,7 +5,7 @@ wrench   = require 'wrench'
 GitHub   = require 'github-releases'
 Progress = require 'progress'
 
-TaskName = "download-atom-shell"
+TaskName = "download-electron-shell"
 
 module.exports = (grunt) ->
   spawn = (options, callback) ->
@@ -130,17 +130,17 @@ module.exports = (grunt) ->
 
   rebuildNativeModules = (apm, previousVersion, currentVersion, needToRebuild, callback) ->
     if currentVersion isnt previousVersion and needToRebuild
-      grunt.verbose.writeln "Rebuilding native modules for new atom-shell version #{currentVersion}."
+      grunt.verbose.writeln "Rebuilding native modules for new electron version #{currentVersion}."
       apm ?= getApmPath()
       env = ATOM_NODE_VERSION: currentVersion.substr(1)
       spawn {cmd: apm, args: ['rebuild'], env}, callback
     else
       callback()
 
-  grunt.registerTask TaskName, 'Download atom-shell',  ->
+  grunt.registerTask TaskName, 'Download electron',  ->
     @requiresConfig "#{TaskName}.version", "#{TaskName}.outputDir"
     {version, outputDir, downloadDir, symbols, rebuild, apm, token} = grunt.config TaskName
-    downloadDir ?= path.join os.tmpdir(), 'downloaded-atom-shell'
+    downloadDir ?= path.join os.tmpdir(), 'downloaded-electron'
     symbols ?= false
     rebuild ?= true
     apm ?= getApmPath()
@@ -150,19 +150,19 @@ module.exports = (grunt) ->
 
     if versionCompare(strippedVersion, "0.24.0", 
         lexicographical: false
-        zeroExtend: true) >= 0
-      grunt.log.error "Unable to use this task for versions 0.24.0 or higher - please use 'download-electron-shell' instead."
+        zeroExtend: true) < 0
+      grunt.log.error "Unable to use this task for versions less than 0.24.0 - please use 'download-atom-shell' instead."
       return false
 
     done = @async()
 
-    # Do nothing if the desired version of atom-shell is already installed.
+    # Do nothing if the desired version of electron is already installed.
     currentAtomShellVersion = getAtomShellVersion(outputDir)
     return done() if currentAtomShellVersion is version
 
-    # Install a cached download of atom-shell if one is available.
+    # Install a cached download of electron if one is available.
     if getAtomShellVersion(versionDownloadDir)?
-      grunt.verbose.writeln("Installing cached atom-shell #{version}.")
+      grunt.verbose.writeln("Installing cached electron #{version}.")
       copyDirectory(versionDownloadDir, outputDir)
       rebuildNativeModules apm, currentAtomShellVersion, version, rebuild, done
       return
@@ -177,47 +177,47 @@ module.exports = (grunt) ->
       # Which file to download
       filename =
         if symbols
-          "atom-shell-#{version}-#{process.platform}-#{getArch()}-symbols.zip"
+          "electron-#{version}-#{process.platform}-#{getArch()}-symbols.zip"
         else
-          "atom-shell-#{version}-#{process.platform}-#{getArch()}.zip"
+          "electron-#{version}-#{process.platform}-#{getArch()}.zip"
 
       # Find the asset of current platform.
       for asset in releases[0].assets when asset.name is filename
         github.downloadAsset asset, (error, inputStream) ->
           if error?
-            grunt.log.error "Cannot download atom-shell #{version}", error
+            grunt.log.error "Cannot download electron #{version}", error
             return done false
 
           # Save file to cache.
-          grunt.verbose.writeln "Downloading atom-shell #{version}."
-          downloadAndUnzip inputStream, path.join(versionDownloadDir, "atom-shell.zip"), (error) ->
+          grunt.verbose.writeln "Downloading electron #{version}."
+          downloadAndUnzip inputStream, path.join(versionDownloadDir, "electron.zip"), (error) ->
             if error?
-              grunt.log.error "Failed to download atom-shell #{version}", error
+              grunt.log.error "Failed to download electron #{version}", error
               return done false
 
-            grunt.verbose.writeln "Installing atom-shell #{version}."
+            grunt.verbose.writeln "Installing electron #{version}."
             copyDirectory(versionDownloadDir, outputDir)
             rebuildNativeModules apm, currentAtomShellVersion, version, rebuild, done
         return
 
-      grunt.log.error "Cannot find #{filename} in atom-shell #{version} release"
+      grunt.log.error "Cannot find #{filename} in electron #{version} release"
       done false
 
-  grunt.registerTask "#{TaskName}-chromedriver", 'Download the chromedriver binary distributed with atom-shell',  ->
+  grunt.registerTask "#{TaskName}-chromedriver", 'Download the chromedriver binary distributed with electron',  ->
     @requiresConfig "#{TaskName}.version", "#{TaskName}.outputDir"
     {version, outputDir, downloadDir, token} = grunt.config(TaskName)
     version = "v#{version}"
-    downloadDir ?= path.join os.tmpdir(), 'downloaded-atom-shell'
+    downloadDir ?= path.join os.tmpdir(), 'downloaded-electron'
     chromedriverPath = path.join(outputDir, "chromedriver")
 
     done = @async()
 
     # Chromedriver is only distributed with the first patch release for any
-    # given major and minor version of atom-shell.
+    # given major and minor version of electron.
     versionWithChromedriver = version.split(".").slice(0, 2).join(".") + ".0"
     downloadPath = path.join(downloadDir, "#{versionWithChromedriver}-chromedriver")
 
-    # Do nothing if the desired version of atom-shell is already installed with
+    # Do nothing if the desired version of electron is already installed with
     # a chromedriver executable.
     currentAtomShellVersion = getAtomShellVersion(outputDir)
     return done() if currentAtomShellVersion is version and grunt.file.isDir(chromedriverPath)
@@ -229,10 +229,10 @@ module.exports = (grunt) ->
       return done()
 
     # Request the assets.
-    github = new GitHub({repo: 'atom/atom-shell', token})
+    github = new GitHub({repo: 'atom/electron', token})
     github.getReleases tag_name: versionWithChromedriver, (error, releases) ->
       unless releases?.length > 0
-        grunt.log.error "Cannot find atom-shell #{versionWithChromedriver} from GitHub", error
+        grunt.log.error "Cannot find electron #{versionWithChromedriver} from GitHub", error
         return done false
 
       # Find the asset for the current platform and architecture.
@@ -240,20 +240,20 @@ module.exports = (grunt) ->
       for asset in releases[0].assets when assetNameRegex.test(asset.name)
         github.downloadAsset asset, (error, inputStream) ->
           if error?
-            grunt.log.error "Cannot download chromedriver for atom-shell #{versionWithChromedriver}", error
+            grunt.log.error "Cannot download chromedriver for electron #{versionWithChromedriver}", error
             return done false
 
           # Save file to cache.
-          grunt.verbose.writeln "Downloading chromedriver for atom-shell #{versionWithChromedriver}."
+          grunt.verbose.writeln "Downloading chromedriver for electron #{versionWithChromedriver}."
           downloadAndUnzip inputStream, path.join(downloadPath, "chromedriver.zip"), (error) ->
             if error?
-              grunt.log.error "Failed to download chromedriver for atom-shell #{versionWithChromedriver}", error
+              grunt.log.error "Failed to download chromedriver for electron #{versionWithChromedriver}", error
               return done false
 
-            grunt.verbose.writeln "Installing chromedriver for atom-shell #{versionWithChromedriver}."
+            grunt.verbose.writeln "Installing chromedriver for electron #{versionWithChromedriver}."
             copyDirectory(downloadPath, chromedriverPath)
             done()
         return
 
-      grunt.log.error "Cannot find chromedriver in atom-shell #{versionWithChromedriver} release"
+      grunt.log.error "Cannot find chromedriver in electron #{versionWithChromedriver} release"
       done false


### PR DESCRIPTION
This includes the rename of the repository as well as the new file names that releases have.  I left it as two tasks for the different version-sets to make it clear to users that the downloaded files and package info will be different as of 0.24.0