### PR TITLE
Use the process environment when spawning apm. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ grunt.loadNpmTasks('grunt-download-atom-shell');
 * `rebuild` - Whether to rebuild native modules after atom-shell is downloaded.
 * `apm` - The path to apm.
 * `token` - The [OAuth token](https://developer.github.com/v3/oauth/) to use for GitHub API requests.
+* `appDir` - Where to find the app when rebuilding the native modules.  Defaults to the current directory.
 
 ### Usage
 

--- a/tasks/download-atom-shell-task.coffee
+++ b/tasks/download-atom-shell-task.coffee
@@ -93,24 +93,33 @@ module.exports = (grunt) ->
       process.stdout.cursorTo?(0)
       progress.tick(chunk.length)
 
-  rebuildNativeModules = (apm, previousVersion, currentVersion, needToRebuild, callback) ->
+  rebuildNativeModules = (apm, previousVersion, currentVersion, needToRebuild, callback, appDir) ->
     if currentVersion isnt previousVersion and needToRebuild
       grunt.verbose.writeln "Rebuilding native modules for new electron version #{currentVersion}."
       apm ?= getApmPath()
-      env = ATOM_NODE_VERSION: currentVersion.substr(1)
-      spawn {cmd: apm, args: ['rebuild'], env}, callback
+
+      # When we spawn apm, we still want to use the global environment variables
+      options = env: process.env
+      options.env.ATOM_NODE_VERSION = currentVersion.substr(1)
+
+      # If the appDir has been set, then that is where we want to perform the rebuild.
+      # it defaults to the current directory
+      if (appDir?)
+        options.cwd = appDir
+      spawn {cmd: apm, args: ['rebuild'], opts: options}, callback
     else
       callback()
 
   grunt.registerTask TaskName, 'Download electron',  ->
     @requiresConfig "#{TaskName}.version", "#{TaskName}.outputDir"
-    {version, outputDir, downloadDir, symbols, rebuild, apm, token} = grunt.config TaskName
+    {version, outputDir, downloadDir, symbols, rebuild, apm, token, appDir} = grunt.config TaskName
     downloadDir ?= path.join os.tmpdir(), 'downloaded-electron'
     symbols ?= false
     rebuild ?= true
     apm ?= getApmPath()
     version = "v#{version}"
     versionDownloadDir = path.join(downloadDir, version)
+    appDir ?= process.cwd()
 
     done = @async()
 
@@ -122,7 +131,7 @@ module.exports = (grunt) ->
     if getAtomShellVersion(versionDownloadDir)?
       grunt.verbose.writeln("Installing cached electron #{version}.")
       copyDirectory(versionDownloadDir, outputDir)
-      rebuildNativeModules apm, currentAtomShellVersion, version, rebuild, done
+      rebuildNativeModules apm, currentAtomShellVersion, version, rebuild, done, appDir
       return
 
     # Request the assets.
@@ -155,7 +164,7 @@ module.exports = (grunt) ->
 
             grunt.verbose.writeln "Installing electron #{version}."
             copyDirectory(versionDownloadDir, outputDir)
-            rebuildNativeModules apm, currentAtomShellVersion, version, rebuild, done
+            rebuildNativeModules apm, currentAtomShellVersion, version, rebuild, done, appDir
         return
 
       grunt.log.error "Cannot find #{filename} in electron #{version} release"

--- a/tasks/download-atom-shell-task.coffee
+++ b/tasks/download-atom-shell-task.coffee
@@ -104,7 +104,7 @@ module.exports = (grunt) ->
 
       # If the appDir has been set, then that is where we want to perform the rebuild.
       # it defaults to the current directory
-      if (appDir?)
+      if appDir?
         options.cwd = appDir
       spawn {cmd: apm, args: ['rebuild'], opts: options}, callback
     else


### PR DESCRIPTION
 Also allow the setting of the app directory for rebuilding modules - this allows an arbitrary location for the app in relation to this task.