### PR TITLE
Gc 20511 double grunt

### DIFF
--- a/tasks/download-atom-shell-task.coffee
+++ b/tasks/download-atom-shell-task.coffee
@@ -97,7 +97,9 @@ module.exports = (grunt) ->
       progress.tick(chunk.length)
 
   rebuildNativeModules = (apm, previousVersion, currentVersion, needToRebuild, callback, appDir) ->
-    if currentVersion isnt previousVersion and needToRebuild
+    # Note: In our fork, we skip "apm" below because of it's causing problems for GC-20511.
+    # "apm" doesn't seem to be doing anything important as far as Eagle Desktop is concerned.
+    if false and currentVersion isnt previousVersion and needToRebuild
       grunt.verbose.writeln "Rebuilding native modules for new electron version #{currentVersion}."
       apm ?= getApmPath()
 

--- a/tasks/download-atom-shell-task.coffee
+++ b/tasks/download-atom-shell-task.coffee
@@ -25,7 +25,7 @@ module.exports = (grunt) ->
 
   getArch = ->
     switch process.platform
-      when 'win32' then 'ia32'
+      when 'win32' then 'x64'
       when 'darwin' then 'x64'
       else process.arch
 


### PR DESCRIPTION
Fixes download-electron to no longer fail when "apm" is not installed

Now suppress "apm" as it doesn't seem to do much as far as Eagle Desktop is concerned.

Note: "apm" would be installed automatically the first time Atom (not Atom Shell) is run

eagle-desktop test link is [here](https://github.com/GrabCAD/eagle-desktop/pull/223)